### PR TITLE
Utility - 관리자 계정 삭제

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "prestart": "npm run build",
     "start": "node dist/main.js",
     "prenewAdmin": "npm run build",
-    "newAdmin": "node dist/utilsRunner/newAdmin.runner.js"
+    "newAdmin": "node dist/utilsRunner/newAdmin.runner.js",
+    "predeleteAdmin": "npm run build",
+    "deleteAdmin": "node dist/utilsRunner/deleteAdmin.runner.js"
   },
   "engines": {
     "node": ">=12.9.0"

--- a/src/datatypes/authentication/Admin.ts
+++ b/src/datatypes/authentication/Admin.ts
@@ -91,4 +91,25 @@ export default class Admin implements LoginCredentials {
       new Date(queryResult[0].membersince)
     );
   }
+
+  /**
+   * Delete an existing entry in admin table
+   *
+   * @param dbClient DB Connection Pool
+   * @param username username associated with the Admin
+   * @return {Promise<mariadb.UpsertResult>} db operation result
+   */
+  static async delete(
+    dbClient: mariadb.Pool,
+    username: string
+  ): Promise<mariadb.UpsertResult> {
+    const queryResult = await dbClient.query(
+      'DELETE FROM admin WHERE username = ?',
+      username
+    );
+    if (queryResult.affectedRows === 0) {
+      throw new NotFoundError();
+    }
+    return queryResult;
+  }
 }

--- a/src/functions/utils/deleteAdmin.ts
+++ b/src/functions/utils/deleteAdmin.ts
@@ -1,0 +1,40 @@
+/**
+ * Utility to delete existing admin account
+ * - Able to called from terminal
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import * as mariadb from 'mariadb';
+import ServerConfigTemplate from '../../ServerConfigTemplate';
+import Admin from '../../datatypes/authentication/Admin';
+
+/**
+ * Function to delete existing admin account
+ *
+ * @param username username of delete target
+ * @param config instance of ServerConfigTemplate, containing DB connection information
+ */
+export default async function deleteAdmin(
+  username: string,
+  config: ServerConfigTemplate
+): Promise<mariadb.UpsertResult> {
+  // Create new admin entry on database
+  const dbClient = mariadb.createPool({
+    host: config.db.url,
+    port: config.db.port,
+    user: config.db.username,
+    password: config.db.password,
+    database: config.db.defaultDatabase,
+    compress: true,
+  });
+  let result;
+  try {
+    result = await Admin.delete(dbClient, username);
+    await dbClient.end();
+  } catch (e) {
+    await dbClient.end();
+    throw e;
+  }
+  return result;
+}

--- a/src/utilsRunner/deleteAdmin.runner.ts
+++ b/src/utilsRunner/deleteAdmin.runner.ts
@@ -1,0 +1,53 @@
+/**
+ * Runner to execute deleteAdmin() function on the command-line
+ *  - Delete an exsiting admin account
+ *
+ * Need one Command-Line Arguments (Starts from 2)
+ *  2. username
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import ServerConfig from '../ServerConfig';
+import deleteAdmin from '../functions/utils/deleteAdmin';
+
+// Check Command-Line Argument (2 for system-generated, 1 provided)
+if (process.argv.length !== 3) {
+  console.error(
+    String.prototype.concat(
+      'Incorrect number of command-line arguments provided!!\n\n',
+      'Please check how to use the function and try again.\n',
+      'usage: node dist/utilsRunner/deleteAdmin.runner.js [username] [password] [name]'
+    )
+  );
+  // eslint-disable-next-line no-process-exit
+  process.exit(1);
+}
+
+// Parse username and Call deleteAdmin()
+const config = new ServerConfig();
+deleteAdmin(process.argv[2], config).then(
+  // DB Operation Success
+  value => {
+    if (value.affectedRows !== 1) {
+      console.error(
+        String.prototype.concat(
+          'No affectedRows!!\n\n',
+          'Check query result manually!!'
+        )
+      );
+      // eslint-disable-next-line no-process-exit
+      process.exit(1);
+    } else {
+      console.log('Successfully deleted existing admin account');
+      // eslint-disable-next-line no-process-exit
+      process.exit();
+    }
+  },
+  // DB Operation Fail
+  error => {
+    console.error(error);
+    // eslint-disable-next-line no-process-exit
+    process.exit(1);
+  }
+);

--- a/src/utilsRunner/newAdmin.runner.ts
+++ b/src/utilsRunner/newAdmin.runner.ts
@@ -19,7 +19,7 @@ if (process.argv.length !== 5) {
     String.prototype.concat(
       'Incorrect number of command-line arguments provided!!\n\n',
       'Please check how to use the function and try again.\n',
-      'usage: node dist/utils/newAdmin.js [username] [password] [name]'
+      'usage: node dist/utilsRunner/newAdmin.runner.js [username] [password] [name]'
     )
   );
   // eslint-disable-next-line no-process-exit

--- a/test/testcases/utils/deleteAdmin.test.ts
+++ b/test/testcases/utils/deleteAdmin.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Jest unit test for utility to delete an existing admin account
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import TestEnv from '../../TestEnv';
+import TestConfig from '../../TestConfig';
+import deleteAdmin from '../../../src/functions/utils/deleteAdmin';
+
+describe('POST /auth/login - login', () => {
+  let testEnv: TestEnv;
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup TestEnv
+    testEnv = new TestEnv(expect.getState().currentTestName);
+
+    // Start Test Environment
+    await testEnv.start();
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Success', async () => {
+    try {
+      // Call deleteAdmin function
+      const result = await deleteAdmin('testuser1', testEnv.testConfig);
+      expect(result.affectedRows).toBe(1);
+
+      // DB Check
+      const queryResult = await testEnv.dbClient.query('SELECT * FROM admin');
+      expect(queryResult.length).toBe(1);
+      expect(queryResult[0].username).toBe('testuser2');
+      expect(queryResult[0].name).toBe('김철수');
+      expect(queryResult[0].password).toBe(
+        TestConfig.hash(
+          'testuser2',
+          new Date(queryResult[0].membersince).toISOString(),
+          'Password12!'
+        )
+      );
+    } catch (e) {
+      fail();
+    }
+  });
+
+  test('Success - Have Sessions (Cleared)', async () => {
+    // Login Request
+    let loginCredentials = {username: 'testuser1', password: 'Password13!'};
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+
+    loginCredentials = {username: 'testuser2', password: 'Password12!'};
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+
+    try {
+      // Call deleteAdmin function
+      const result = await deleteAdmin('testuser1', testEnv.testConfig);
+      expect(result.affectedRows).toBe(1);
+
+      // DB Check - admin
+      let queryResult = await testEnv.dbClient.query('SELECT * FROM admin');
+      expect(queryResult.length).toBe(1);
+      expect(queryResult[0].username).toBe('testuser2');
+      expect(queryResult[0].name).toBe('김철수');
+      expect(queryResult[0].password).toBe(
+        TestConfig.hash(
+          'testuser2',
+          new Date(queryResult[0].membersince).toISOString(),
+          'Password12!'
+        )
+      );
+
+      // DB Check - admin_session
+      queryResult = await testEnv.dbClient.query(
+        'SELECT * FROM admin_session WHERE username = ?',
+        'testuser1'
+      );
+      expect(queryResult.length).toBe(0);
+
+      queryResult = await testEnv.dbClient.query('SELECT * FROM admin_session');
+      expect(queryResult.length).toBe(1);
+      expect(queryResult[0].username).toBe('testuser2');
+    } catch (e) {
+      fail();
+    }
+  });
+
+  test('Fail - No matching username', async () => {
+    try {
+      // Call deleteAdmin function
+      await deleteAdmin('notexist', testEnv.testConfig);
+      fail();
+    } catch (e) {
+      expect(e.message).toBe('Not Found');
+    }
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query('SELECT * FROM admin');
+    expect(queryResult.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Close #4 

- 관리자가 ID를 입력하여 기존 관리자 계정을 삭제할 수 있음
- 기존 newAdmin() 유틸리티의 에러 메세지를 수정하였음