### PR TITLE
DELETE /auth/logout: 로그아웃 & GET /auth/renew: 토큰 갱신

### DIFF
--- a/src/datatypes/authentication/AdminSession.ts
+++ b/src/datatypes/authentication/AdminSession.ts
@@ -1,0 +1,67 @@
+/**
+ * Define type and CRUD methods for each admin_session entry
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import * as mariadb from 'mariadb';
+
+/**
+ * Class for AdminSession
+ */
+export default class AdminSession {
+  username: string;
+  token: string;
+  expires: Date;
+
+  /**
+   * Constructor for AdminSession Object
+   *
+   * @param username unique username of the admin
+   * @param refreshToken refreshToken associated with the session
+   * @param expires When the token expires
+   */
+  constructor(username: string, refreshToken: string, expires: Date) {
+    this.username = username;
+    this.token = refreshToken;
+    this.expires = expires;
+  }
+
+  /**
+   * Create new entry in admin_session table
+   *
+   * @param dbClient DB Connection Pool (MariaDB)
+   * @param session AdminSession Information
+   * @return {Promise<mariadb.UpsertResult>} db operation result
+   */
+  static async create(
+    dbClient: mariadb.Pool,
+    session: AdminSession
+  ): Promise<mariadb.UpsertResult> {
+    return await dbClient.query(
+      String.prototype.concat(
+        'INSERT INTO admin_session ',
+        '(username, token, expires) ',
+        'VALUES (?, ?, ?)'
+      ),
+      [session.username, session.token, session.expires]
+    );
+  }
+
+  /**
+   * Delete an existing entry in admin_session table by username
+   *
+   * @param dbClient DB Connection Pool
+   * @param username username indicating the owner of session
+   * @return {Promise<mariadb.UpsertResult>} db operation result
+   */
+  static async deleteByUsername(
+    dbClient: mariadb.Pool,
+    username: string
+  ): Promise<mariadb.UpsertResult> {
+    return await dbClient.query(
+      'DELETE FROM admin_session WHERE username = ?',
+      [username]
+    );
+  }
+}

--- a/src/datatypes/authentication/AdminSession.ts
+++ b/src/datatypes/authentication/AdminSession.ts
@@ -41,7 +41,7 @@ export default class AdminSession {
   ): Promise<mariadb.UpsertResult> {
     return await dbClient.query(
       String.prototype.concat(
-        'INSERT INTO admin_session ',
+        'REPLACE INTO admin_session ',
         '(username, token, expires) ',
         'VALUES (?, ?, ?)'
       ),

--- a/src/datatypes/authentication/JWTObject.ts
+++ b/src/datatypes/authentication/JWTObject.ts
@@ -1,0 +1,15 @@
+/**
+ * Object type definition for JWT Token Payload
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import AuthToken from './AuthToken';
+
+/**
+ * Interface to define JSON Web Token contents
+ */
+export default interface JWTObject extends AuthToken {
+  iat?: number; // issued at
+  exp?: number; // expire at
+}

--- a/src/datatypes/authentication/RefreshTokenVerifyResult.ts
+++ b/src/datatypes/authentication/RefreshTokenVerifyResult.ts
@@ -1,0 +1,18 @@
+/**
+ * Define type for the objects that contains the result
+ * for RefreshToken verification
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import AuthToken from './AuthToken';
+
+/**
+ * Interface to define RefreshToken's verification result
+ * When RefreshToken is about to expire,
+ *   newToken field contains new RefreshToken that must be returned to user
+ */
+export default interface RefreshTokenVerifyResult {
+  content: AuthToken; // token contents
+  newToken?: string; // new JWT token (created when the token is about to expire)
+}

--- a/src/functions/JWT/verifyRefreshToken.ts
+++ b/src/functions/JWT/verifyRefreshToken.ts
@@ -1,0 +1,73 @@
+/**
+ * Verifying Refresh Token (JSON Web Token)
+ *
+ * @author Hyecheol (Jerry) Jang
+ */
+
+import {Request} from 'express';
+import * as mariadb from 'mariadb';
+import * as jwt from 'jsonwebtoken';
+import AdminSession from '../../datatypes/authentication/AdminSession';
+import AuthToken from '../../datatypes/authentication/AuthToken';
+import JWTObject from '../../datatypes/authentication/JWTObject';
+import RefreshTokenVerifyResult from '../../datatypes/authentication/RefreshTokenVerifyResult';
+import AuthenticationError from '../../exceptions/AuthenticationError';
+import createRefreshToken from './createRefreshToken';
+
+export default async function verifyRefreshToken(
+  req: Request,
+  jwtRefreshKey: string,
+  dbClient: mariadb.Pool
+): Promise<RefreshTokenVerifyResult> {
+  if (!('X-REFRESH-TOKEN' in req.cookies)) {
+    throw new AuthenticationError();
+  }
+  let tokenContents: JWTObject; // place to store contents of JWT
+  // Verify and retrieve the token contents
+  try {
+    tokenContents = jwt.verify(req.cookies['X-REFRESH-TOKEN'], jwtRefreshKey, {
+      algorithms: ['HS512'],
+    }) as JWTObject;
+  } catch (e) {
+    throw new AuthenticationError();
+  }
+  if (tokenContents.type !== 'refresh') {
+    throw new AuthenticationError();
+  }
+
+  // Check token in DB
+  try {
+    const dbToken = await AdminSession.read(
+      dbClient,
+      req.cookies['X-REFRESH-TOKEN']
+    );
+    /* istanbul ignore if */
+    if (dbToken.expires < new Date()) {
+      throw new AuthenticationError();
+    }
+  } catch (e) {
+    /* istanbul ignore else */
+    if (e.message === 'Not Found') {
+      throw new AuthenticationError();
+    } else {
+      throw e;
+    }
+  }
+
+  // If RefreshToken expires within 20min, create new refresh token and delete previous one
+  const expectedExpire = new Date();
+  expectedExpire.setMinutes(new Date().getMinutes() + 20);
+  let newRefreshToken;
+  if (new Date((tokenContents.exp as number) * 1000) < expectedExpire) {
+    // Less than 20 min remaining
+    newRefreshToken = await createRefreshToken(
+      dbClient,
+      tokenContents.username,
+      jwtRefreshKey
+    );
+  }
+
+  delete tokenContents.iat;
+  delete tokenContents.exp;
+  return {content: tokenContents as AuthToken, newToken: newRefreshToken};
+}

--- a/src/functions/JWT/verifyRefreshToken.ts
+++ b/src/functions/JWT/verifyRefreshToken.ts
@@ -14,6 +14,15 @@ import RefreshTokenVerifyResult from '../../datatypes/authentication/RefreshToke
 import AuthenticationError from '../../exceptions/AuthenticationError';
 import createRefreshToken from './createRefreshToken';
 
+/**
+ * Method to verify refreshToken
+ *
+ * @param req Express Request object
+ * @param jwtRefreshKey JWT Refresh Token secret
+ * @param dbClient DB Connection Pool
+ * @return {Promise<RefreshTokenVerifyResult>} verification result of refresh token
+ *   (new token included if the refresh token is about to expire)
+ */
 export default async function verifyRefreshToken(
   req: Request,
   jwtRefreshKey: string,

--- a/src/functions/utils/deleteAdmin.ts
+++ b/src/functions/utils/deleteAdmin.ts
@@ -30,6 +30,8 @@ export default async function deleteAdmin(
   });
   let result;
   try {
+    // Delete of admin record automatically deletes admin_session information
+    // ON DELETE CASCADE
     result = await Admin.delete(dbClient, username);
     await dbClient.end();
   } catch (e) {

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -140,16 +140,8 @@ authRouter.get('/renew', async (req, res, next) => {
     const refreshToken = verifyResult.newToken;
 
     // Check admin user existence
-    try {
-      await Admin.read(dbClient, verifyResult.content.username);
-    } catch (e) {
-      /* istanbul ignore else */
-      if (e.statusCode === 404) {
-        throw new AuthenticationError();
-      } else {
-        throw e;
-      }
-    }
+    // When admin user entry deleted, associated admin_session also removed
+    // (ON DELETE CASCADE)
 
     // Create new AccessToken
     const accessToken = createAccessToken(

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -93,4 +93,18 @@ authRouter.post('/login', async (req, res, next) => {
   }
 });
 
+// DELETE: auth/logout
+authRouter.delete('/logout', async (req, res, next) => {
+  const dbClient: mariadb.Pool = req.app.locals.dbClient;
+
+  try {
+    // TODO: Verify Refresh Token
+    // TODO: Retrieve Refresh Token
+    // TODO: Remove token from DB
+    // TODO: Clear Cookie & Response
+  } catch (e) {
+    next(e);
+  }
+});
+
 export default authRouter;

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -17,6 +17,7 @@ import checkPasswordRule from '../functions/inputValidator/checkPasswordRule';
 import createAccessToken from '../functions/JWT/createAccessToken';
 import createRefreshToken from '../functions/JWT/createRefreshToken';
 import verifyRefreshToken from '../functions/JWT/verifyRefreshToken';
+import AdminSession from '../datatypes/authentication/AdminSession';
 
 // Path: /auth
 const authRouter = express.Router();
@@ -111,8 +112,13 @@ authRouter.delete('/logout', async (req, res, next) => {
       refreshToken = verifyResult.newToken;
     }
 
-    // TODO: Remove token from DB
-    // TODO: Clear Cookie & Response
+    // Remove token from DB
+    await AdminSession.deleteByToken(dbClient, refreshToken);
+
+    // Clear Cookie & Response
+    res.clearCookie('X-ACCESS-TOKEN', {httpOnly: true, maxAge: 0});
+    res.clearCookie('X-REFRESH-TOKEN', {httpOnly: true, maxAge: 0});
+    res.status(200).send();
   } catch (e) {
     next(e);
   }

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -16,6 +16,7 @@ import checkUsernameRule from '../functions/inputValidator/checkUsernameRule';
 import checkPasswordRule from '../functions/inputValidator/checkPasswordRule';
 import createAccessToken from '../functions/JWT/createAccessToken';
 import createRefreshToken from '../functions/JWT/createRefreshToken';
+import verifyRefreshToken from '../functions/JWT/verifyRefreshToken';
 
 // Path: /auth
 const authRouter = express.Router();
@@ -98,8 +99,18 @@ authRouter.delete('/logout', async (req, res, next) => {
   const dbClient: mariadb.Pool = req.app.locals.dbClient;
 
   try {
-    // TODO: Verify Refresh Token
-    // TODO: Retrieve Refresh Token
+    // Verify Refresh Token
+    const verifyResult = await verifyRefreshToken(
+      req,
+      req.app.get('jwtRefreshKey'),
+      dbClient
+    );
+    // Retrieve Refresh Token
+    let refreshToken = req.cookies['X-REFRESH-TOKEN'];
+    if (verifyResult.newToken !== undefined) {
+      refreshToken = verifyResult.newToken;
+    }
+
     // TODO: Remove token from DB
     // TODO: Clear Cookie & Response
   } catch (e) {

--- a/test/testcases/auth/delete.logout.test.ts
+++ b/test/testcases/auth/delete.logout.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Jest unit test for DELETE /auth/logout method
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import * as jwt from 'jsonwebtoken';
+// eslint-disable-next-line node/no-unpublished-import
+import MockDate from 'mockdate';
+import TestEnv from '../../TestEnv';
+import AuthToken from '../../../src/datatypes/authentication/AuthToken';
+
+describe('DELETE /auth/logout - logout from current session', () => {
+  let testEnv: TestEnv;
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup TestEnv
+    testEnv = new TestEnv(expect.getState().currentTestName);
+    await testEnv.start();
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Success Logout', async () => {
+    const currentDate = new Date();
+    // Login
+    MockDate.set(currentDate);
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+    const refreshToken = response.header['set-cookie'][1]
+      .split('; ')[0]
+      .split('=')[1];
+    // Dummy Login (Other user)
+    currentDate.setSeconds(currentDate.getSeconds() + 1);
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser2', password: 'Password12!'});
+    expect(response.status).toBe(200);
+
+    // Logout request
+    currentDate.setSeconds(currentDate.getSeconds() + 1);
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app)
+      .delete('/auth/logout')
+      .set('Cookie', [`X-REFRESH-TOKEN=${refreshToken}`]);
+    expect(response.status).toBe(200);
+
+    // Cookie Clear Check
+    let cookie = response.header['set-cookie'][0].split('; ')[0].split('=');
+    expect(cookie[0]).toBe('X-ACCESS-TOKEN'); // Check for Access Token Name
+    expect(cookie[1]).toBe('');
+    cookie = response.header['set-cookie'][1].split('; ')[0].split('=');
+    expect(cookie[0]).toBe('X-REFRESH-TOKEN'); // check for Refresh Token Name
+    expect(cookie[1]).toBe('');
+
+    // DB Check
+    let queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM admin_session WHERE username = ?',
+      'testuser1'
+    );
+    expect(queryResult.length).toBe(0);
+    queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM admin_session WHERE username = ?',
+      'testuser2'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(new Date(queryResult[0].expires) > new Date()).toBe(true);
+    const expireDate = new Date();
+    expireDate.setMinutes(expireDate.getMinutes() + 121);
+    expect(new Date(queryResult[0].expires) < expireDate).toBe(true);
+  });
+
+  test('Success logout - about to expire refreshToken', async () => {
+    const currentDate = new Date();
+    // Login
+    MockDate.set(currentDate);
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+    const refreshToken = response.header['set-cookie'][1]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Logout request
+    currentDate.setMinutes(currentDate.getMinutes() + 101); // about to expire
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app)
+      .delete('/auth/logout')
+      .set('Cookie', [`X-REFRESH-TOKEN=${refreshToken}`]);
+    expect(response.status).toBe(200);
+
+    // Cookie Clear Check
+    let cookie = response.header['set-cookie'][0].split('; ')[0].split('=');
+    expect(cookie[0]).toBe('X-ACCESS-TOKEN'); // Check for Access Token Name
+    expect(cookie[1]).toBe('');
+    cookie = response.header['set-cookie'][1].split('; ')[0].split('=');
+    expect(cookie[0]).toBe('X-REFRESH-TOKEN'); // check for Refresh Token Name
+    expect(cookie[1]).toBe('');
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM admin_session WHERE username = ?',
+      'testuser1'
+    );
+    expect(queryResult.length).toBe(0);
+  });
+
+  test('Fail - Use accessToken to logout', async () => {
+    const currentDate = new Date();
+    // Login
+    MockDate.set(currentDate);
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+    const accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Logout request
+    currentDate.setMinutes(currentDate.getMinutes() + 1);
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app)
+      .delete('/auth/logout')
+      .set('Cookie', [`X-REFRESH-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(401);
+
+    // Cookie Clear Check (Should not be cleared)
+    expect(response.header['set-cookie']).toBeUndefined();
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM admin_session WHERE username = ?',
+      'testuser1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(new Date(queryResult[0].expires) > new Date()).toBe(true);
+    const expireDate = new Date();
+    expireDate.setMinutes(expireDate.getMinutes() + 121);
+    expect(new Date(queryResult[0].expires) < expireDate).toBe(true);
+  });
+
+  test('Fail - Use unregistered refreshToken', async () => {
+    const currentDate = new Date();
+    // Create RefreshToken
+    MockDate.set(currentDate);
+    const tokenContents: AuthToken = {
+      username: 'testuser1',
+      type: 'refresh',
+    };
+    const jwtOption: jwt.SignOptions = {
+      algorithm: 'HS512',
+      expiresIn: '120m',
+    };
+    const refreshToken = jwt.sign(
+      tokenContents,
+      testEnv.testConfig.jwt.refreshKey,
+      jwtOption
+    );
+
+    // Login request
+    currentDate.setSeconds(currentDate.getSeconds() + 1);
+    MockDate.set(currentDate);
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+
+    // Logout request
+    currentDate.setMinutes(currentDate.getMinutes() + 1);
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app)
+      .delete('/auth/logout')
+      .set('Cookie', [`X-REFRESH-TOKEN=${refreshToken}`]);
+    expect(response.status).toBe(401);
+
+    // Cookie Clear Check (Should not be cleared)
+    expect(response.header['set-cookie']).toBeUndefined();
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM admin_session WHERE username = ?',
+      'testuser1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(new Date(queryResult[0].expires) > new Date()).toBe(true);
+    const expireDate = new Date();
+    expireDate.setMinutes(expireDate.getMinutes() + 121);
+    expect(new Date(queryResult[0].expires) < expireDate).toBe(true);
+  });
+
+  test('Fail - Use expired refreshToken', async () => {
+    const currentDate = new Date();
+    // Login request
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+    const refreshToken = response.header['set-cookie'][1]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Logout request
+    currentDate.setMinutes(currentDate.getMinutes() + 121); // expired
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app)
+      .delete('/auth/logout')
+      .set('Cookie', [`X-REFRESH-TOKEN=${refreshToken}`]);
+    expect(response.status).toBe(401);
+
+    // Cookie Clear Check (Should not be cleared)
+    expect(response.header['set-cookie']).toBeUndefined();
+
+    // Check DB Server - Meaningless here
+  });
+
+  test('Fail - Use refreshToken generated with wrong secret key', async () => {
+    const currentDate = new Date();
+    // Create RefreshToken
+    MockDate.set(currentDate);
+    const tokenContents: AuthToken = {
+      username: 'testuser1',
+      type: 'refresh',
+    };
+    const jwtOption: jwt.SignOptions = {
+      algorithm: 'HS512',
+      expiresIn: '120m',
+    };
+    const refreshToken = jwt.sign(tokenContents, 'dummyKey', jwtOption);
+
+    // Login request
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+
+    // Logout request
+    currentDate.setMinutes(currentDate.getMinutes() + 1);
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app)
+      .delete('/auth/logout')
+      .set('Cookie', [`X-REFRESH-TOKEN=${refreshToken}`]);
+    expect(response.status).toBe(401);
+
+    // Cookie Clear Check (Should not be cleared)
+    expect(response.header['set-cookie']).toBeUndefined();
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM admin_session WHERE username = ?',
+      'testuser1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(new Date(queryResult[0].expires) > new Date()).toBe(true);
+    const expireDate = new Date();
+    expireDate.setMinutes(expireDate.getMinutes() + 121);
+    expect(new Date(queryResult[0].expires) < expireDate).toBe(true);
+  });
+
+  test('Fail - Use refreshToken generated with wrong type value', async () => {
+    const currentDate = new Date();
+    // Create RefreshToken
+    MockDate.set(currentDate);
+    const tokenContents: AuthToken = {
+      username: 'testuser1',
+      type: 'access',
+    };
+    const jwtOption: jwt.SignOptions = {
+      algorithm: 'HS512',
+      expiresIn: '15m',
+    };
+    const accessToken = jwt.sign(
+      tokenContents,
+      testEnv.testConfig.jwt.refreshKey,
+      jwtOption
+    );
+
+    // Login request
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+
+    // Logout request
+    currentDate.setMinutes(currentDate.getMinutes() + 1);
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app)
+      .delete('/auth/logout')
+      .set('Cookie', [`X-REFRESH-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(401);
+
+    // Cookie Clear Check (Should not be cleared)
+    expect(response.header['set-cookie']).toBeUndefined();
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM admin_session WHERE username = ?',
+      'testuser1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(new Date(queryResult[0].expires) > new Date()).toBe(true);
+    const expireDate = new Date();
+    expireDate.setMinutes(expireDate.getMinutes() + 121);
+    expect(new Date(queryResult[0].expires) < expireDate).toBe(true);
+  });
+
+  test('Fail - No Token', async () => {
+    const currentDate = new Date();
+    // Login request
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+
+    // Logout request
+    currentDate.setMinutes(currentDate.getMinutes() + 1);
+    MockDate.set(currentDate);
+    response = await request(testEnv.expressServer.app).delete('/auth/logout');
+    expect(response.status).toBe(401);
+
+    // Cookie Clear Check (Should not be cleared)
+    expect(response.header['set-cookie']).toBeUndefined();
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM admin_session WHERE username = ?',
+      'testuser1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(new Date(queryResult[0].expires) > new Date()).toBe(true);
+    const expireDate = new Date();
+    expireDate.setMinutes(expireDate.getMinutes() + 121);
+    expect(new Date(queryResult[0].expires) < expireDate).toBe(true);
+  });
+});

--- a/test/testcases/auth/get.renew.test.ts
+++ b/test/testcases/auth/get.renew.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Jest unit test for GET /auth/renew method
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import * as jwt from 'jsonwebtoken';
+// eslint-disable-next-line node/no-unpublished-import
+import MockDate from 'mockdate';
+import TestEnv from '../../TestEnv';
+import AuthToken from '../../../src/datatypes/authentication/AuthToken';
+
+describe('GET /auth/renew - renew access/refresh token', () => {
+  let testEnv: TestEnv;
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup TestEnv
+    testEnv = new TestEnv(expect.getState().currentTestName);
+    await testEnv.start();
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Success', async () => {
+    const currentDate = new Date();
+
+    // Login
+    MockDate.set(currentDate);
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send({username: 'testuser1', password: 'Password13!'});
+    expect(response.status).toBe(200);
+    const refreshToken = response.header['set-cookie'][1]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Both token alive - need to process renewal request
+    // Renew Request
+    response = await request(testEnv.expressServer.app)
+      .get('/auth/renew')
+      .set('Cookie', [`X-REFRESH-TOKEN=${refreshToken}`]);
+    expect(response.status).toBe(200);
+
+    // Check Cookie and Token Values
+    const jwtOption: jwt.VerifyOptions = {algorithms: ['HS512']};
+    // Parse Access Token
+    let cookie = response.header['set-cookie'][0].split('; ')[0].split('=');
+    expect(cookie[0]).toBe('X-ACCESS-TOKEN'); // Check for Access Token Name
+    let tokenPayload = jwt.verify(
+      cookie[1],
+      testEnv.testConfig.jwt.secretKey,
+      jwtOption
+    ) as AuthToken; // Check for AccessToken contents
+    expect(tokenPayload.username).toBe('testuser1');
+    expect(tokenPayload.type).toBe('access');
+
+    // Passed 20 min (Refresh token alive, access token expired
+    currentDate.setMinutes(currentDate.getMinutes() + 20);
+    MockDate.set(currentDate);
+    // Renew Request
+    response = await request(testEnv.expressServer.app)
+      .get('/auth/renew')
+      .set('Cookie', [`X-REFRESH-TOKEN=${refreshToken}`]);
+    expect(response.status).toBe(200);
+
+    // Check Cookie and Token Values
+    // Parse Access Token
+    cookie = response.header['set-cookie'][0].split('; ')[0].split('=');
+    expect(cookie[0]).toBe('X-ACCESS-TOKEN'); // Check for Access Token Name
+    tokenPayload = jwt.verify(
+      cookie[1],
+      testEnv.testConfig.jwt.secretKey,
+      jwtOption
+    ) as AuthToken; // Check for AccessToken contents
+    expect(tokenPayload.username).toBe('testuser1');
+    expect(tokenPayload.type).toBe('access');
+  });
+
+  test('Success - Refresh Token about to expire', async () => {});
+
+  test('Fail - Invalid Token', async () => {});
+
+  test('Fail - No Token', async () => {});
+
+  test('Fail - Token not in DB (logged out)', async () => {});
+
+  test('Fail - Admin user deleted', async () => {});
+});


### PR DESCRIPTION
Close #7 / Close #9 

로그아웃 API와 토큰 갱신 API를 동시에 작업하였음

1. 로그아웃 (관리자 전용): 리프레시 토큰 확인 후 DB에서 세션정보 삭제 / 클라이언트에서 토큰정보가 담긴 쿠키 삭제명령
2. 토큰 갱신 (관리자 전용): 리프래시 토큰을 이용하여 엑세스 토큰을 재발급함. 만약 리프래시 토큰이 만료 직전이면 (만료 15분 전) 리프래시 토큰의 재발급도 함께 진행

### Change Logs
기능
- 리프래시 토큰 확인 후 로그아웃 진행
  - DB에서 세션정보 삭제
  - 리프래시 토큰이 재발급 된경우, 재발급 된 토큰도 삭제
  - 쿠키를 삭제하는 명령 반환
- 리프래시 토큰 확인 후 토큰 갱신
  - 필요한 경우 리프래시 토큰 재발행 / 이 경우 기존 토큰 삭제

DB
- admin_session 테이블의 엔트리를 추가, 삭제, 가져오는 함수를 별도의 클래스로 분리

JWT 토큰
- 리프레시 토큰을 검증하는 코드 추가
  - 리프래시 토큰이 만료 직전인 경우, 새 토큰 발급 / 추후 클라이언트에게 반환 필요