### PR TITLE
GET /{year}-{month}: 달 별 이벤트 목록 API

### DIFF
--- a/src/ExpressServer.ts
+++ b/src/ExpressServer.ts
@@ -11,6 +11,7 @@ import ServerConfig from './ServerConfig';
 import HTTPError from './exceptions/HTTPError';
 import authRouter from './routes/auth';
 import eventRouter from './routes/event';
+import calendarRouter from './routes/calendar';
 
 /**
  * Class contains Express Application and other relevant instances/functions
@@ -63,6 +64,7 @@ export default class ExpressServer {
     // Routers
     this.app.use('/auth', authRouter);
     this.app.use('/event', eventRouter);
+    this.app.use('/', calendarRouter);
 
     // Default Error Handler
     this.app.use(

--- a/src/datatypes/calendar/CalendarEventResponse.ts
+++ b/src/datatypes/calendar/CalendarEventResponse.ts
@@ -1,0 +1,23 @@
+/**
+ * Define type for the objects that reply as a response of GET /{year}-{month}
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+/**
+ * Interface to define event entry of response.eventList
+ */
+export interface EventEntry {
+  id: number;
+  name: string;
+  date: number;
+  category: string | undefined;
+}
+
+/**
+ * Interface to define response of GET /{year}-{month}
+ */
+export default interface CalendarEventResponse {
+  numEvent: number;
+  eventList: Array<EventEntry> | undefined;
+}

--- a/src/datatypes/event/Event.ts
+++ b/src/datatypes/event/Event.ts
@@ -7,6 +7,18 @@
 import * as mariadb from 'mariadb';
 
 /**
+ * Interface to define event entry in DB
+ */
+interface EventDB {
+  id: number;
+  date: string;
+  name: string;
+  detail: string | null;
+  category: string | null;
+  editor: string;
+}
+
+/**
  * Class for Event
  */
 export default class Event {
@@ -31,8 +43,8 @@ export default class Event {
     date: Date,
     name: string,
     editor: string,
-    detail?: string,
-    category?: string,
+    detail?: string | null,
+    category?: string | null,
     id?: number
   ) {
     this.date = date;
@@ -91,13 +103,9 @@ export default class Event {
       [startDate, endDate]
     );
 
-    return queryResult.map(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore
-      qr => {
-        const {date, name, editor, detail, category, id} = qr;
-        return new Event(new Date(date), name, editor, detail, category, id);
-      }
-    );
+    return queryResult.map((qr: EventDB) => {
+      const {date, name, editor, detail, category, id} = qr;
+      return new Event(new Date(date), name, editor, detail, category, id);
+    });
   }
 }

--- a/src/datatypes/event/Event.ts
+++ b/src/datatypes/event/Event.ts
@@ -10,6 +10,7 @@ import * as mariadb from 'mariadb';
  * Class for Event
  */
 export default class Event {
+  id: number | null; // Event ID
   date: Date; // Event Date
   name: string; // Event Name
   detail: string | null; // Event detailed description
@@ -24,25 +25,22 @@ export default class Event {
    * @param editor username of admin who edit the event lastly
    * @param detail Event detailed description
    * @param category Event category
+   * @param id numeric id (From DB)
    */
   constructor(
     date: Date,
     name: string,
     editor: string,
     detail?: string,
-    category?: string
+    category?: string,
+    id?: number
   ) {
     this.date = date;
     this.name = name;
     this.editor = editor;
-    this.detail = null;
-    this.category = null;
-    if (detail !== undefined) {
-      this.detail = detail;
-    }
-    if (category !== undefined) {
-      this.category = category;
-    }
+    this.detail = detail ? detail : null;
+    this.category = category ? category : null;
+    this.id = id ? id : null;
   }
 
   /**
@@ -63,6 +61,43 @@ export default class Event {
         'VALUES (?, ?, ?, ?, ?)'
       ),
       [event.date, event.name, event.detail, event.category, event.editor]
+    );
+  }
+
+  /**
+   * Retrieve events of specific month
+   *
+   * @param dbClient DB Connection Pool (mariaDB)
+   * @param year year
+   * @param month month
+   * @return {Promise<Array<Event>>} return array of Events
+   */
+  static async readByDate(
+    dbClient: mariadb.Pool,
+    year: number,
+    month: number
+  ): Promise<Array<Event>> {
+    // Get start and end date of the month
+    const startDate = new Date(year, month - 1, 1);
+    const endDate = new Date(
+      year,
+      month - 1,
+      new Date(year, month, 0).getDate()
+    );
+
+    // Query
+    const queryResult = await dbClient.query(
+      'SELECT * FROM event WHERE date BETWEEN ? AND ?',
+      [startDate, endDate]
+    );
+
+    return queryResult.map(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
+      qr => {
+        const {date, name, editor, detail, category, id} = qr;
+        return new Event(new Date(date), name, editor, detail, category, id);
+      }
     );
   }
 }

--- a/src/routes/calendar.ts
+++ b/src/routes/calendar.ts
@@ -1,0 +1,58 @@
+/**
+ * express Router middleware for Calendar API
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import * as express from 'express';
+import * as mariadb from 'mariadb';
+import BadRequestError from '../exceptions/BadRequestError';
+import Event from '../datatypes/event/Event';
+import CalendarEventResponse, {
+  EventEntry,
+} from '../datatypes/calendar/CalendarEventResponse';
+
+// Path : /
+const calendarRouter = express.Router();
+
+// GET: /{year}-{month}
+calendarRouter.get('/:year-:month', async (req, res, next) => {
+  const dbClient: mariadb.Pool = req.app.locals.dbClient;
+  const year = parseInt(req.params.year);
+  const month = parseInt(req.params.month);
+
+  try {
+    // Check for number
+    if (isNaN(year) || isNaN(month)) {
+      throw new BadRequestError();
+    }
+    // Check for year and month range
+    if (year < 2021 || month < 1 || month > 12) {
+      throw new BadRequestError();
+    }
+
+    // Retrieve events from DB
+    const eventList = await Event.readByDate(dbClient, year, month);
+    if (eventList.length === 0) {
+      res.status(200).json({numEvent: 0});
+    } else {
+      const replyObj: CalendarEventResponse = {
+        numEvent: eventList.length,
+        eventList: [],
+      };
+      eventList.forEach(e => {
+        (replyObj.eventList as EventEntry[]).push({
+          id: e.id as number,
+          name: e.name,
+          date: new Date(e.date).getDate(),
+          category: e.category ? e.category : undefined,
+        });
+      });
+      res.status(200).json(replyObj);
+    }
+  } catch (e) {
+    next(e);
+  }
+});
+
+export default calendarRouter;

--- a/test/testcases/calendar/get.{year}-{month}.test.ts
+++ b/test/testcases/calendar/get.{year}-{month}.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Jest unit test for GET /{year}-{month} method
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import TestEnv from '../../TestEnv';
+
+describe('GET /{year}-{month}', () => {
+  let testEnv: TestEnv;
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup test environment
+    testEnv = new TestEnv(expect.getState().currentTestName);
+
+    // Start Test Environment
+    await testEnv.start();
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Success - No Event', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app).get('/2022-01');
+    expect(response.status).toBe(200);
+    expect(response.body.numEvent).toBe(0);
+    expect(Object.keys(response.body).length).toBe(1);
+  });
+
+  test('Success - Multiple Event (with/without category)', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app).get('/2021-08');
+    expect(response.status).toBe(200);
+    expect(response.body.numEvent).toBe(2);
+    const {eventList} = response.body;
+    eventList.forEach((e: {name: string; date: number; category: string}) => {
+      if (e.name === '광복절') {
+        expect(e.date).toBe(15);
+        expect(e.category).toBeUndefined();
+        expect(Object.keys(e).length).toBe(3);
+      } else {
+        expect(e.date).toBe(26);
+        expect(e.category).toBe('비대면 모임');
+        expect(Object.keys(e).length).toBe(4);
+      }
+    });
+    expect(Object.keys(response.body).length).toBe(2);
+  });
+
+  test('Success - One Event (without category)', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app).get('/2021-12');
+    expect(response.status).toBe(200);
+    expect(response.body.numEvent).toBe(1);
+    expect(response.body.eventList[0].name).toBe('연말 결산 모임');
+    expect(response.body.eventList[0].date).toBe(31);
+    expect(Object.keys(response.body.eventList[0]).length).toBe(3);
+    expect(Object.keys(response.body).length).toBe(2);
+  });
+
+  test('Success - One Event (with category)', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app).get('/2021-10');
+    expect(response.status).toBe(200);
+    expect(response.body.numEvent).toBe(1);
+    expect(response.body.eventList[0].name).toBe('할로윈 파티');
+    expect(response.body.eventList[0].date).toBe(31);
+    expect(response.body.eventList[0].category).toBe('네트워킹');
+    expect(Object.keys(response.body.eventList[0]).length).toBe(4);
+    expect(Object.keys(response.body).length).toBe(2);
+  });
+
+  test('Success - Newly Added Event', async () => {
+    // Information that used during the test
+    const loginCredentials = {
+      username: 'testuser1',
+      password: 'Password13!',
+    };
+    const requiredPayload = {
+      year: 2022,
+      month: 1,
+      date: 1,
+      name: '신년 해돋이',
+    };
+
+    // Admin Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+    const accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Add new event
+    response = await request(testEnv.expressServer.app)
+      .post('/event')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`])
+      .send({
+        ...requiredPayload,
+        detail: '신년 맞이 일출을 광안리에서 봅니다.',
+        category: '네트워킹',
+      });
+    expect(response.status).toBe(200);
+
+    // Get Event
+    response = await request(testEnv.expressServer.app).get('/2022-01');
+    expect(response.status).toBe(200);
+    expect(response.body.numEvent).toBe(1);
+    expect(response.body.eventList[0].name).toBe('신년 해돋이');
+    expect(response.body.eventList[0].date).toBe(1);
+    expect(response.body.eventList[0].category).toBe('네트워킹');
+    expect(Object.keys(response.body.eventList[0]).length).toBe(4);
+    expect(Object.keys(response.body).length).toBe(2);
+  });
+
+  test('Fail - Non number params', async () => {
+    // Non-Number Month
+    let response = await request(testEnv.expressServer.app).get('/2022-jan');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+
+    // Non-number year
+    response = await request(testEnv.expressServer.app).get('/this-01');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+
+    // Non-number year and month
+    response = await request(testEnv.expressServer.app).get('/this-jan');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+  });
+
+  test('Fail - Invalid month', async () => {
+    let response = await request(testEnv.expressServer.app).get('/2022-13');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+
+    response = await request(testEnv.expressServer.app).get('/2022-00');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+  });
+
+  test('Fail - Invalid year', async () => {
+    const response = await request(testEnv.expressServer.app).get('/1997-6');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+  });
+});


### PR DESCRIPTION
close #14 

주어진 년도와 달의 이벤트 개수와 목록을 불러옴. 2021년 1월 이후의 달만 지원
만약, 주어진 달에 이벤트가 없는 경우, 이벤트가 없다는 명시적인 응답이 주어짐

### Change Logs

기능
- 달 별 이벤트 목록 받아오는 API 작성
  - 2021년 01월 이후의 달만 지원

DB
- event 테이블의 엔트리를 달별로 검색하는 쿼리 작성
