### PR TITLE
DELETE /event/{eventID}: 이벤트 삭제 API

### DIFF
--- a/src/datatypes/event/Event.ts
+++ b/src/datatypes/event/Event.ts
@@ -79,7 +79,7 @@ export default class Event {
     eventID: number
   ): Promise<mariadb.UpsertResult> {
     const queryResult = await dbClient.query(
-      'DELETE FROM table WHERE id = ?',
+      'DELETE FROM event WHERE id = ?',
       eventID
     );
     if (queryResult.affectedRows === 0) {

--- a/src/datatypes/event/Event.ts
+++ b/src/datatypes/event/Event.ts
@@ -5,6 +5,7 @@
  */
 
 import * as mariadb from 'mariadb';
+import NotFoundError from '../../exceptions/NotFoundError';
 
 /**
  * Class for Event
@@ -64,5 +65,26 @@ export default class Event {
       ),
       [event.date, event.name, event.detail, event.category, event.editor]
     );
+  }
+
+  /**
+   * Delete an existing event from database
+   *
+   * @param dbClient DB Connection Pool
+   * @param eventID unique event ID associated with the Event
+   * @return {Promise<mariadb.UpsertResult>} db operation result
+   */
+  static async delete(
+    dbClient: mariadb.Pool,
+    eventID: number
+  ): Promise<mariadb.UpsertResult> {
+    const queryResult = await dbClient.query(
+      'DELETE FROM table WHERE id = ?',
+      eventID
+    );
+    if (queryResult.affectedRows === 0) {
+      throw new NotFoundError();
+    }
+    return queryResult;
   }
 }

--- a/src/routes/event.ts
+++ b/src/routes/event.ts
@@ -7,6 +7,7 @@
 import * as express from 'express';
 import * as mariadb from 'mariadb';
 import BadRequestError from '../exceptions/BadRequestError';
+import NotFoundError from '../exceptions/NotFoundError';
 import Event from '../datatypes/event/Event';
 import EventForm from '../datatypes/event/EventForm';
 import {validateEventForm} from '../functions/inputValidator/event/validateEventForm';
@@ -76,7 +77,7 @@ eventRouter.delete('/:eventId', async (req, res, next) => {
 
     // Check for numeric id, >= 1
     if (isNaN(eventId) || eventId < 1) {
-      throw new BadRequestError();
+      throw new NotFoundError();
     }
 
     // DB Operation

--- a/src/routes/event.ts
+++ b/src/routes/event.ts
@@ -66,5 +66,27 @@ eventRouter.post('/', async (req, res, next) => {
 // PUT: /event/{eventID}
 
 // DELETE: /event/{eventID}
+eventRouter.delete('/:eventId', async (req, res, next) => {
+  const dbClient: mariadb.Pool = req.app.locals.dbClient;
+  const eventId = parseInt(req.params.eventId);
+
+  try {
+    // Verify Admin Access Token
+    await verifyAccessToken(req, req.app.get('jwtAccessKey'));
+
+    // Check for numeric id, >= 1
+    if (isNaN(eventId) || eventId < 1) {
+      throw new BadRequestError();
+    }
+
+    // DB Operation
+    await Event.delete(dbClient, eventId);
+
+    // Response
+    res.status(200).send();
+  } catch (e) {
+    next(e);
+  }
+});
 
 export default eventRouter;

--- a/test/TestEnv.ts
+++ b/test/TestEnv.ts
@@ -166,7 +166,7 @@ export default class TestEnv {
       '네트워킹',
       'testuser1',
     ]);
-    // 2021-08-15, 광복절, N/A, N/A, testuser1
+    // 2021-08-15, 광복절, N/A, N/A, testuser2
     eventSamples.push([
       new Date(2021, 7, 15),
       '광복절',

--- a/test/testcases/event/delete.{eventID}.test.ts
+++ b/test/testcases/event/delete.{eventID}.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Jest unit test for DELETE /event/{eventID} method
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import TestEnv from '../../TestEnv';
+
+describe('DELETE /event/{eventID} - Delete an existing event', () => {
+  let testEnv: TestEnv;
+
+  // Information that used during the test
+  const loginCredentials = {
+    username: 'testuser1',
+    password: 'Password13!',
+  };
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup test environment
+    testEnv = new TestEnv(expect.getState().currentTestName);
+
+    // Start Test Environment
+    await testEnv.start();
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Success - Delete event that I newly registered', async () => {
+    // Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+    const accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Register a event
+    response = await request(testEnv.expressServer.app)
+      .post('/event')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`])
+      .send({year: 2022, month: 1, date: 1, name: '신년 해돋이'});
+    expect(response.status).toBe(200);
+
+    // Delete the event
+    response = await request(testEnv.expressServer.app)
+      .delete('/event/5')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query('SELECT * FROM event');
+    expect(queryResult.length).toBe(4);
+    const checkTarget = queryResult.filter((r: {id: number}) => r.id === 1);
+    expect(checkTarget.date.toISOString()).toBe(
+      new Date(2021, 9, 31).toISOString()
+    );
+    expect(checkTarget.name).toBe('할로윈 파티');
+    expect(checkTarget.detail).toBe(undefined);
+    expect(checkTarget.category).toBe('네트워킹');
+    expect(checkTarget.editor).toBe('testuser1');
+  });
+
+  test('Success - Delete event that I previously registered', async () => {
+    // Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+    const accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Delete the event
+    response = await request(testEnv.expressServer.app)
+      .delete('/event/1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query('SELECT * FROM event');
+    expect(queryResult.length).toBe(3);
+    const checkTarget = queryResult.filter((r: {id: number}) => r.id === 2);
+    expect(checkTarget.date.toISOString()).toBe(
+      new Date(2021, 7, 15).toISOString()
+    );
+    expect(checkTarget.name).toBe('광복절');
+    expect(checkTarget.detail).toBe(undefined);
+    expect(checkTarget.category).toBe(undefined);
+    expect(checkTarget.editor).toBe('testuser2');
+  });
+
+  test('Success - Delete event that other person registered', async () => {
+    // Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+    const accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Delete the event
+    response = await request(testEnv.expressServer.app)
+      .delete('/event/3')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query('SELECT * FROM event');
+    expect(queryResult.length).toBe(3);
+    const checkTarget = queryResult.filter((r: {id: number}) => r.id === 2);
+    expect(checkTarget.date.toISOString()).toBe(
+      new Date(2021, 7, 15).toISOString()
+    );
+    expect(checkTarget.name).toBe('광복절');
+    expect(checkTarget.detail).toBe(undefined);
+    expect(checkTarget.category).toBe(undefined);
+    expect(checkTarget.editor).toBe('testuser2');
+  });
+
+  test('Success - Delete event with duplicated name', async () => {});
+
+  test('Fail - Not authorized user', async () => {});
+
+  test('Fail - Invalid Event ID', async () => {});
+
+  test('Fail - Event ID Not Found', async () => {});
+});

--- a/test/testcases/event/post.test.ts
+++ b/test/testcases/event/post.test.ts
@@ -20,12 +20,7 @@ describe('POST /event - Create new event', () => {
     username: 'testuser1',
     password: 'Password13!',
   };
-  const requiredPayload = {
-    year: 2022,
-    month: 1,
-    date: 1,
-    name: '신년 해돋이',
-  };
+  const requiredPayload = {year: 2022, month: 1, date: 1, name: '신년 해돋이'};
 
   beforeAll(() => {
     jest.setTimeout(120000);
@@ -119,10 +114,7 @@ describe('POST /event - Create new event', () => {
     response = await request(testEnv.expressServer.app)
       .post('/event')
       .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`])
-      .send({
-        ...requiredPayload,
-        category: '네트워킹',
-      });
+      .send({...requiredPayload, category: '네트워킹'});
     expect(response.status).toBe(200);
 
     // DB Test
@@ -293,12 +285,7 @@ describe('POST /event - Create new event', () => {
     response = await request(testEnv.expressServer.app)
       .post('/event')
       .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`])
-      .send({
-        year: 2022,
-        month: 2,
-        date: 30,
-        name: 'BGM 워크샵',
-      });
+      .send({year: 2022, month: 2, date: 30, name: 'BGM 워크샵'});
     expect(response.status).toBe(400);
     expect(response.body.error).toBe('Bad Request');
 


### PR DESCRIPTION
close #12 

관리자의 이벤트 토큰 검증 후 기존 이벤트를 삭제함. 이 경우, 이미 등록된 참여자 목록도 함께 삭제됨.
기존 이벤트의 식별자 (eventID) 필요

### Change Logs

기능
- 이벤트 삭제 API

DB
- event 테이블의 엔트리를 id를 참조해 지우는 쿼리 작성
- AUTO_INCREMENT 속성이 부여된 id가 1씩 증가하는것이 아니라는 점을 발견