### PR TITLE
POST /event/{eventID}/participate: 이벤트 참가 신청 API

### DIFF
--- a/src/datatypes/participate/Participation.ts
+++ b/src/datatypes/participate/Participation.ts
@@ -1,0 +1,100 @@
+/**
+ * Define type and CRUD methods for each participate entry
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import * as mariadb from 'mariadb';
+
+export default class Participation {
+  id: number | null; // Participation ticket ID
+  eventId: number; // associated Event ID
+  date: Date; // When the ticket created
+  participantName: string; // Name of participant
+  phoneNumber: string | null; // Optional field for phone number
+  email: string; // email is required
+  comment: string | null; // additional comment
+
+  constructor(
+    eventId: number,
+    date: Date,
+    participantName: string,
+    email: string,
+    phoneNumber?: string | null,
+    comment?: string | null,
+    id?: number
+  ) {
+    this.eventId = eventId;
+    this.date = date;
+    this.participantName = participantName;
+    this.email = email;
+    this.phoneNumber = phoneNumber ? phoneNumber : null;
+    this.comment = comment ? comment : null;
+    this.id = id ? id : null;
+  }
+
+  /**
+   * Create new entry in participate table
+   *
+   * @param dbClient DB Connection Pool (MariaDB)
+   * @param participation Participation Information
+   * @return {Promise<mariadb.UpsertResult>} db operation result
+   */
+  static async create(
+    dbClient: mariadb.Pool,
+    participation: Participation
+  ): Promise<mariadb.UpsertResult> {
+    const {eventId, date, participantName, phoneNumber, email, comment} =
+      participation;
+    return await dbClient.query(
+      String.prototype.concat(
+        'INSERT INTO participation ',
+        '(event_id, date, participant_name, phone_number, email, comment) ',
+        'VALUES (?, ?, ?, ?, ?, ?)'
+      ),
+      [eventId, date, participantName, phoneNumber, email, comment]
+    );
+  }
+
+  /**
+   * Retrieve a participate table's entry using eventId, name, and email
+   *
+   * @param dbClient DB Connection Pool (MariaDB)
+   * @param eventId unique id referring the event
+   * @param name participant's name
+   * @param email participant's email
+   * @return {Promise<Participation | undefined>} either undefined
+   *   or found Participation
+   */
+  static async readByEventIdNameEmail(
+    dbClient: mariadb.Pool,
+    eventId: number,
+    name: string,
+    email: string
+  ): Promise<Participation | undefined> {
+    // DB Query
+    const queryResult = await dbClient.query(
+      String.prototype.concat(
+        'SELECT * FROM participation ',
+        'WHERE event_id = ? AND participant_name = ? AND email = ?'
+      ),
+      [eventId, name, email]
+    );
+
+    if (queryResult.length === 0) {
+      return undefined;
+    } else {
+      const {id, event_id, date} = queryResult[0];
+      const {participant_name, phone_number, email, comment} = queryResult[0];
+      return new Participation(
+        event_id,
+        new Date(date),
+        participant_name,
+        email,
+        phone_number,
+        comment,
+        id
+      );
+    }
+  }
+}

--- a/src/datatypes/participate/ParticipationForm.ts
+++ b/src/datatypes/participate/ParticipationForm.ts
@@ -1,0 +1,19 @@
+/**
+ * Define type for participate form
+ *   - participantName
+ *   - phoneNumber (optional)
+ *   - email
+ *   - comment (optional)
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+/**
+ * Interface for ParticipationForm
+ */
+export default interface ParticipationForm {
+  participantName: string;
+  email: string;
+  phoneNumber?: string;
+  comment?: string;
+}

--- a/src/functions/inputValidator/participate/validateParticipationForm.ts
+++ b/src/functions/inputValidator/participate/validateParticipationForm.ts
@@ -1,0 +1,20 @@
+/**
+ * Validate user input - Participation Form
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import Ajv from 'ajv';
+import addFormats from 'ajv-formats';
+
+export const validateParticipationForm = addFormats(new Ajv()).compile({
+  type: 'object',
+  properties: {
+    participantName: {type: 'string'},
+    email: {type: 'string', format: 'email'},
+    phoneNumber: {type: 'string'},
+    comment: {type: 'string'},
+  },
+  required: ['participantName', 'email'],
+  additionalProperties: false,
+});

--- a/src/routes/event.ts
+++ b/src/routes/event.ts
@@ -14,6 +14,7 @@ import EventEditForm from '../datatypes/event/EventEditForm';
 import {validateEventForm} from '../functions/inputValidator/event/validateEventForm';
 import {validateEventEditForm} from '../functions/inputValidator/event/validateEventEditForm';
 import verifyAccessToken from '../functions/JWT/verifyAccessToken';
+import participateRouter from './participate';
 
 // Path: /event
 const eventRouter = express.Router();
@@ -176,5 +177,8 @@ eventRouter.delete('/:eventId', async (req, res, next) => {
     next(e);
   }
 });
+
+// Participate Router Path: /event/{eventID}/participate
+eventRouter.use('/:eventId/participate', participateRouter);
 
 export default eventRouter;

--- a/src/routes/participate.ts
+++ b/src/routes/participate.ts
@@ -1,0 +1,70 @@
+/**
+ * express Router middleware for Participate APIs
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+import * as express from 'express';
+import * as mariadb from 'mariadb';
+import BadRequestError from '../exceptions/BadRequestError';
+import NotFoundError from '../exceptions/NotFoundError';
+import Event from '../datatypes/event/Event';
+import Participation from '../datatypes/participate/Participation';
+import ParticipationForm from '../datatypes/participate/ParticipationForm';
+import {validateParticipationForm} from '../functions/inputValidator/participate/validateParticipationForm';
+
+// Path: /event/{eventID}/participate
+const participateRouter = express.Router({mergeParams: true});
+
+// POST /event/{eventID}/participate
+participateRouter.post('/', async (req, res, next) => {
+  const dbClient: mariadb.Pool = req.app.locals.dbClient;
+  const eventId = parseInt((req.params as {eventId: string}).eventId);
+
+  try {
+    // Check for numeric id, >= 1
+    if (isNaN(eventId) || eventId < 1) {
+      throw new NotFoundError();
+    }
+
+    // Verify User Input
+    const participationForm: ParticipationForm = req.body;
+    if (!validateParticipationForm(participationForm)) {
+      throw new BadRequestError();
+    }
+
+    // Check Event Existence
+    await Event.read(dbClient, eventId);
+
+    // Check duplicated (having same name and email)
+    const {participantName, email, phoneNumber, comment} = participationForm;
+    if (
+      await Participation.readByEventIdNameEmail(
+        dbClient,
+        eventId,
+        participantName,
+        email
+      )
+    ) {
+      throw new BadRequestError();
+    }
+
+    // Add request to DB
+    const newEntry = new Participation(
+      eventId,
+      new Date(),
+      participantName,
+      email,
+      phoneNumber,
+      comment
+    );
+    await Participation.create(dbClient, newEntry);
+
+    // Response
+    res.status(200).send();
+  } catch (e) {
+    next(e);
+  }
+});
+
+export default participateRouter;

--- a/test/testcases/participate/post.test.ts
+++ b/test/testcases/participate/post.test.ts
@@ -1,0 +1,371 @@
+/**
+ * Jest unit test for POST /event/{eventID}/participate method
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import TestEnv from '../../TestEnv';
+
+describe('POST /event/{eventID}/participate - Create new participate', () => {
+  let testEnv: TestEnv;
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup test environment
+    testEnv = new TestEnv(expect.getState().currentTestName);
+
+    // Start Test Environment
+    await testEnv.start();
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Success - Three participation created', async () => {
+    // Clear existing participation list
+    await testEnv.dbClient.query('DELETE FROM participation');
+
+    // All field
+    let response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(200);
+
+    // Same name, but different email, without comment
+    response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong123@gmail.com',
+      });
+    expect(response.status).toBe(200);
+
+    // Different name, same email, only required
+    response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({participantName: '김길동', email: 'gildong@gmail.com'});
+    expect(response.status).toBe(200);
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 1'
+    );
+    expect(queryResult.length).toBe(3);
+    queryResult.forEach(
+      (qr: {
+        participant_name: string;
+        email: string;
+        phone_number?: string;
+        comment?: string;
+      }) => {
+        if (qr.participant_name === '홍길동') {
+          if (qr.email === 'gildong@gmail.com') {
+            expect(qr.phone_number).toBe('01012345678');
+            expect(qr.comment).toBe('test');
+          } else if (qr.email === 'gildong123@gmail.com') {
+            expect(qr.phone_number).toBe('01012345678');
+            expect(qr.comment).toBeNull();
+          } else {
+            fail();
+          }
+        } else if (qr.participant_name === '김길동') {
+          expect(qr.email).toBe('gildong@gmail.com');
+          expect(qr.phone_number).toBeNull();
+          expect(qr.comment).toBeNull();
+        } else {
+          fail();
+        }
+      }
+    );
+  });
+
+  test('Success - Three participation created for different events', async () => {
+    // Clear existing participation list
+    await testEnv.dbClient.query('DELETE FROM participation');
+
+    // Event 1
+    let response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(200);
+    // DB Check
+    let queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(queryResult[0].participant_name).toBe('홍길동');
+    expect(queryResult[0].phone_number).toBe('01012345678');
+    expect(queryResult[0].email).toBe('gildong@gmail.com');
+    expect(queryResult[0].comment).toBe('test');
+
+    // Event 2
+    response = await request(testEnv.expressServer.app)
+      .post('/event/2/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(200);
+    // DB Check
+    queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 2'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(queryResult[0].participant_name).toBe('홍길동');
+    expect(queryResult[0].phone_number).toBe('01012345678');
+    expect(queryResult[0].email).toBe('gildong@gmail.com');
+    expect(queryResult[0].comment).toBe('test');
+
+    // Event 3
+    response = await request(testEnv.expressServer.app)
+      .post('/event/3/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(200);
+    // DB Check
+    queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 3'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(queryResult[0].participant_name).toBe('홍길동');
+    expect(queryResult[0].phone_number).toBe('01012345678');
+    expect(queryResult[0].email).toBe('gildong@gmail.com');
+    expect(queryResult[0].comment).toBe('test');
+  });
+
+  test('Success - Participation created on newly created event', async () => {
+    // Information that used during the test
+    const loginCredentials = {username: 'testuser1', password: 'Password13!'};
+    const requiredPayload = {
+      year: 2022,
+      month: 1,
+      date: 1,
+      name: '신년 해돋이',
+    };
+
+    // Login
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+    const accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Register an event
+    response = await request(testEnv.expressServer.app)
+      .post('/event')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`])
+      .send(requiredPayload);
+    expect(response.status).toBe(200);
+
+    // Get the event id
+    response = await request(testEnv.expressServer.app).get('/2022-1');
+    expect(response.status).toBe(200);
+    const eventId = response.body.eventList[0].id;
+
+    // Register a participation ticket
+    response = await request(testEnv.expressServer.app)
+      .post(`/event/${eventId}/participate`)
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(200);
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      `SELECT * FROM participation WHERE event_id = ${eventId}`
+    );
+    expect(queryResult.length).toBe(1);
+    expect(queryResult[0].participant_name).toBe('홍길동');
+    expect(queryResult[0].phone_number).toBe('01012345678');
+    expect(queryResult[0].email).toBe('gildong@gmail.com');
+    expect(queryResult[0].comment).toBe('test');
+  });
+
+  test('Fail - Missing required field', async () => {
+    // Missing participantName
+    let response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+    // DB Check
+    let queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(queryResult[0].phone_number).not.toBe('01012345678');
+    expect(queryResult[0].email).not.toBe('gildong@gmail.com');
+
+    // Missing email
+    response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        comment: 'test',
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+    // DB Check
+    queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(queryResult[0].phone_number).not.toBe('01012345678');
+    expect(queryResult[0].participant_name).not.toBe('홍길동');
+  });
+
+  test('Fail - Contains additional field', async () => {
+    // Having age
+    const response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+        age: 22,
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(queryResult[0].phone_number).not.toBe('01012345678');
+    expect(queryResult[0].email).not.toBe('gildong@gmail.com');
+  });
+
+  test('Fail - Invalid Event ID (Not a number, less than 1)', async () => {
+    // Non-numeric key
+    let response = await request(testEnv.expressServer.app)
+      .post('/event/halloween/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+
+    // key 0
+    response = await request(testEnv.expressServer.app)
+      .post('/event/0/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+
+    // key -1
+    response = await request(testEnv.expressServer.app)
+      .post('/event/-1/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation'
+    );
+    expect(queryResult.length).toBe(4);
+  });
+
+  test('Fail - Not existing event id', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app)
+      .post('/event/100/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation'
+    );
+    expect(queryResult.length).toBe(4);
+  });
+
+  test('Fail - Duplicated participation ticket', async () => {
+    // Clear existing participation list
+    await testEnv.dbClient.query('DELETE FROM participation');
+
+    // Correct Request
+    let response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(200);
+
+    // Duplicated Request
+    response = await request(testEnv.expressServer.app)
+      .post('/event/1/participate')
+      .send({
+        participantName: '홍길동',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(400);
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 1'
+    );
+    expect(queryResult.length).toBe(1);
+    expect(queryResult[0].phone_number).toBe('01012345678');
+    expect(queryResult[0].email).toBe('gildong@gmail.com');
+    expect(queryResult[0].comment).toBe('test');
+    expect(queryResult[0].participant_name).toBe('홍길동');
+  });
+});


### PR DESCRIPTION
close #23 

새로운 이벤트 참가 신청: 참가자 이름, 연락처 (전화번호 및 이메일) 입력. 추가 의견은 선택적으로 입력

만약 이름 + 이메일의 쌍이 같은 경우, 중복된 참여 요청으로 간주하여 잘못된 요청 (Bad Request)를 반환함


### Change Logs

기능
- 특정 이벤트에 새로이 참가 신청을 하는 API를 작성

DB
- participation 테이블의 새로운 엔트리를 추가하는 쿼리 작성
- eventID와 참가자 이름, 그리고 이메일 주소를 이용해 participation 테이블의 엔트리를 불러오는 쿼리 작성
