### PR TITLE
수정: POST /event/{eventID}/participate - 전화번호 양식 지정

### DIFF
--- a/src/functions/inputValidator/participate/validateParticipationForm.ts
+++ b/src/functions/inputValidator/participate/validateParticipationForm.ts
@@ -12,7 +12,7 @@ export const validateParticipationForm = addFormats(new Ajv()).compile({
   properties: {
     participantName: {type: 'string'},
     email: {type: 'string', format: 'email'},
-    phoneNumber: {type: 'string'},
+    phoneNumber: {type: 'string', pattern: '^010[0-9]{8}$'},
     comment: {type: 'string'},
   },
   required: ['participantName', 'email'],

--- a/test/testcases/participate/post.test.ts
+++ b/test/testcases/participate/post.test.ts
@@ -247,6 +247,38 @@ describe('POST /event/{eventID}/participate - Create new participate', () => {
     expect(queryResult[0].participant_name).not.toBe('홍길동');
   });
 
+  test('Fail - Phone number pattern not valid', async () => {
+    // Request - Having hyphen
+    let response = await request(testEnv.expressServer.app)
+      .post('/event/3/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '010-1234-5678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+
+    // Request - Not a mobile number
+    response = await request(testEnv.expressServer.app)
+      .post('/event/3/participate')
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '070-1234-5678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Bad Request');
+
+    // DB Check
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 3'
+    );
+    expect(queryResult.length).toBe(2);
+  });
+
   test('Fail - Contains additional field', async () => {
     // Having age
     const response = await request(testEnv.expressServer.app)


### PR DESCRIPTION
close #23 

이벤트 참가 신청 API의 전화번호 양식을 지정
- 010 시작 한국 휴대전화번호만 허용
- 숫자만 입력

### Change Logs

기능
- Ajv 인풋 벨리데이터에서 정규식을 사용하여 전화번호 양식을 검사