### PR TITLE
GET /event/{eventID}/participate: 이벤트 참가자 목록 보기 API

### DIFF
--- a/src/datatypes/participate/Participation.ts
+++ b/src/datatypes/participate/Participation.ts
@@ -7,6 +7,19 @@
 import * as mariadb from 'mariadb';
 import NotFoundError from '../../exceptions/NotFoundError';
 
+/**
+ * Interface to define participation entry in DB
+ */
+interface ParticipationDB {
+  id: number;
+  event_id: number;
+  date: string;
+  participant_name: string;
+  phone_number: string | null;
+  email: string;
+  comment: string | null;
+}
+
 export default class Participation {
   id: number | null; // Participation ticket ID
   eventId: number; // associated Event ID
@@ -55,6 +68,36 @@ export default class Participation {
       ),
       [eventId, date, participantName, phoneNumber, email, comment]
     );
+  }
+
+  /**
+   * Retrieve participation tickets associated with specific event
+   *
+   * @param dbClient DB Connection Pool (MariaDB)
+   * @param eventId unique id referring the event
+   * @return {Promise<Array<Participation>>} return array of Participations
+   */
+  static async readByEventId(
+    dbClient: mariadb.Pool,
+    eventId: number
+  ): Promise<Array<Participation>> {
+    // Query
+    const queryResult = await dbClient.query(
+      'SELECT * FROM participation WHERE event_id = ?',
+      [eventId]
+    );
+
+    return queryResult.map((qr: ParticipationDB) => {
+      return new Participation(
+        qr.event_id,
+        new Date(qr.date),
+        qr.participant_name,
+        qr.email,
+        qr.phone_number,
+        qr.comment,
+        qr.id
+      );
+    });
   }
 
   /**

--- a/src/datatypes/participate/ParticipationRetrieveResponse.ts
+++ b/src/datatypes/participate/ParticipationRetrieveResponse.ts
@@ -1,0 +1,25 @@
+/**
+ * Define type for the objects that reply as a response of
+ *   GET /event/{eventId}/participate
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+/**
+ * Interface to define participation entry of response.participantsList
+ */
+export interface ParticipationEntry {
+  id: number;
+  participantName: string;
+  phoneNumber: string | undefined;
+  email: string;
+  comment: string | undefined;
+}
+
+/**
+ * Interface to define response of GET /event/{eventId}/participate
+ */
+export default interface ParticipationRetrieveResponse {
+  numParticipants: number;
+  participantsList: Array<ParticipationEntry> | undefined;
+}

--- a/src/routes/participate.ts
+++ b/src/routes/participate.ts
@@ -85,6 +85,9 @@ participateRouter.get('', async (req, res, next) => {
       throw new NotFoundError();
     }
 
+    // Check for event existence
+    await Event.read(dbClient, eventId);
+
     // DB Operation
     const participationList = await Participation.readByEventId(
       dbClient,

--- a/test/TestEnv.ts
+++ b/test/TestEnv.ts
@@ -215,7 +215,7 @@ export default class TestEnv {
       3,
       new Date('2021-08-20'),
       '김영희',
-      '010-1234-5678',
+      '01012345678',
       'yhkim@gmail.com',
       '음 계정은 yhkim 입니다.',
     ]);
@@ -233,7 +233,7 @@ export default class TestEnv {
       4,
       new Date('2021-08-21'),
       '김말숙',
-      '010-4567-1234',
+      '01045671234',
       'mskim@gmail.com',
       null,
     ]);

--- a/test/testcases/participate/delete.{ticketID}.test.ts
+++ b/test/testcases/participate/delete.{ticketID}.test.ts
@@ -52,7 +52,7 @@ describe('DELETE /event/{eventID}/participate/{ticketID} - Delete an existing ev
     );
     expect(queryResult.length).toBe(1);
     expect(queryResult[0].participant_name).toBe('김영희');
-    expect(queryResult[0].phone_number).toBe('010-1234-5678');
+    expect(queryResult[0].phone_number).toBe('01012345678');
     expect(queryResult[0].email).toBe('yhkim@gmail.com');
     expect(queryResult[0].comment).toBe('음 계정은 yhkim 입니다.');
   });

--- a/test/testcases/participate/get.test.ts
+++ b/test/testcases/participate/get.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Jest unit test for GET /event/{eventID}/participate method
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import TestEnv from '../../TestEnv';
+
+describe('GET /event/{eventID}/participate - Retrieve event participant information', () => {
+  let testEnv: TestEnv;
+
+  // Information that used during the test
+  const loginCredentials = {username: 'testuser1', password: 'Password13!'};
+  let accessToken: string;
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup test environment
+    testEnv = new TestEnv(expect.getState().currentTestName);
+
+    // Start Test Environment
+    await testEnv.start();
+
+    // Login
+    const response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+    accessToken = response.header['set-cookie'][0].split('; ')[0].split('=')[1];
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Success - Multiple participants', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app)
+      .get('/event/3/participate')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.numParticipants).toBe(2);
+    expect(response.body.participantsList.length).toBe(2);
+    response.body.participantsList.forEach(
+      (p: {
+        participantName: string;
+        phoneNumber: string | undefined;
+        email: string;
+        comment: string | undefined;
+        id: number;
+      }) => {
+        if (p.participantName === '김영희') {
+          expect(p.phoneNumber).toBe('01012345678');
+          expect(p.email).toBe('yhkim@gmail.com');
+          expect(p.comment).toBe('음 계정은 yhkim 입니다.');
+          expect(p.id).toBe(2);
+        } else if (p.participantName === '김말숙') {
+          expect(p.phoneNumber).toBeUndefined();
+          expect(p.email).toBe('mskim@gmail.com');
+          expect(p.comment).toBe('음 계정은 mskim 입니다.');
+          expect(p.id).toBe(3);
+        } else {
+          fail();
+        }
+      }
+    );
+  });
+
+  test('Success - Single participant', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app)
+      .get('/event/1/participate')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.numParticipants).toBe(1);
+    expect(response.body.participantsList.length).toBe(1);
+    expect(response.body.participantsList[0].participantName).toBe('김영희');
+    expect(response.body.participantsList[0].phoneNumber).toBeUndefined();
+    expect(response.body.participantsList[0].email).toBe('yhkim@gmail.com');
+    expect(response.body.participantsList[0].comment).toBeUndefined();
+    expect(response.body.participantsList[0].id).toBe(1);
+  });
+
+  test('Success - No participant', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app)
+      .get('/event/2/participate')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.numParticipants).toBe(0);
+    expect(response.body.participantsList).toBeUndefined();
+  });
+
+  test('Success - Newly created event without participant', async () => {
+    // Create new event
+    let response = await request(testEnv.expressServer.app)
+      .post('/event')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`])
+      .send({year: 2022, month: 1, date: 1, name: '신년 해돋이'});
+    expect(response.status).toBe(200);
+
+    // Retrieve Event ID
+    response = await request(testEnv.expressServer.app).get('/2022-1');
+    expect(response.status).toBe(200);
+    const eventId = response.body.eventList[0].id;
+
+    // Get participant list
+    response = await request(testEnv.expressServer.app)
+      .get(`/event/${eventId}/participate`)
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.numParticipants).toBe(0);
+    expect(response.body.participantsList).toBeUndefined();
+  });
+
+  test('Success - Newly created event with participants', async () => {
+    // Create new event
+    let response = await request(testEnv.expressServer.app)
+      .post('/event')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`])
+      .send({year: 2022, month: 1, date: 1, name: '신년 해돋이'});
+    expect(response.status).toBe(200);
+
+    // Retrieve Event ID
+    response = await request(testEnv.expressServer.app).get('/2022-1');
+    expect(response.status).toBe(200);
+    const eventId = response.body.eventList[0].id;
+
+    // Add Participation
+    response = await request(testEnv.expressServer.app)
+      .post(`/event/${eventId}/participate`)
+      .send({
+        participantName: '홍길동',
+        phoneNumber: '01012345678',
+        email: 'gildong@gmail.com',
+        comment: 'test',
+      });
+    expect(response.status).toBe(200);
+
+    // Get participant list
+    response = await request(testEnv.expressServer.app)
+      .get(`/event/${eventId}/participate`)
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+    expect(response.body.numParticipants).toBe(1);
+    expect(response.body.participantsList.length).toBe(1);
+    expect(response.body.participantsList[0].participantName).toBe('홍길동');
+    expect(response.body.participantsList[0].phoneNumber).toBe('01012345678');
+    expect(response.body.participantsList[0].email).toBe('gildong@gmail.com');
+    expect(response.body.participantsList[0].comment).toBe('test');
+  });
+
+  test('Fail - Not authenticated user', async () => {
+    // Request
+    const response = await request(testEnv.expressServer.app).get(
+      '/event/1/participate'
+    );
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe(
+      'Authentication information is missing/invalid'
+    );
+  });
+
+  test('Fail - eventID not valid', async () => {
+    // Request (non-numeric eventID)
+    let response = await request(testEnv.expressServer.app)
+      .get('/event/halloween/participate')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+
+    // Request (eventID = 0)
+    response = await request(testEnv.expressServer.app)
+      .get('/event/0/participate')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+
+    // Request (eventID = -1)
+    response = await request(testEnv.expressServer.app)
+      .get('/event/-1/participate')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+  });
+
+  test('Fail - eventID not found', async () => {
+    // Request (eventID not exist)
+    const response = await request(testEnv.expressServer.app)
+      .get('/event/100/participate')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(404);
+    expect(response.body.error).toBe('Not Found');
+  });
+});


### PR DESCRIPTION
close #25 

이벤트 참가 신청 목록 확인: 특정 이벤트의 참여자, 연락처, 추가 의견을 모두 반환

관리자 전용


### Change Logs

DB
- eventID를 사용하여 모든 participation을 불러오는 쿼리 작성

기능
- 관리자가 특정 이벤트에 종속된 participation을 불러오기 위한 API 작성

테스트
- 테스트 환경을 이전 API의 수정 (휴대전화번호 양식 지정)에 맞추어 변경