### PR TITLE
Optimize DB Queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Data Diagram
   CREATE TABLE admin_session (
     username VARCHAR(12) NOT NULL UNIQUE,
     FOREIGN KEY (username) REFERENCES admin(username) ON DELETE CASCADE ON UPDATE CASCADE,
+    INDEX index_username(username),
     token VARCHAR(255) NOT NULL PRIMARY KEY,
     expires TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    INDEX index_expires(expires)
   ) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
   ```
 
@@ -62,7 +62,8 @@ Data Diagram
   CREATE TABLE event (
     id INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
     date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    INDEX index_date(date),name VARCHAR(255) NOT NULL,
+    INDEX index_date(date),
+    name VARCHAR(255) NOT NULL,
     detail MEDIUMTEXT NULL DEFAULT NULL,
     category VARCHAR(255) NULL DEFAULT NULL,
     editor VARCHAR(12) NOT NULL,
@@ -76,10 +77,13 @@ Data Diagram
     id INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,
     event_id INT(11) NOT NULL,
     FOREIGN KEY (event_id) REFERENCES event(id) ON DELETE CASCADE ON UPDATE CASCADE,
+    INDEX index_event_id(event_id),
     date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     participant_name VARCHAR(255) NOT NULL,
+    INDEX index_participant_name(participant_name),
     phone_number VARCHAR(20) NULL DEFAULT NULL,
     email VARCHAR(255) NOT NULL,
+    INDEX index_email(email),
     comment TEXT NULL DEFAULT NULL
   ) CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
   ```

--- a/src/datatypes/event/Event.ts
+++ b/src/datatypes/event/Event.ts
@@ -131,6 +131,24 @@ export default class Event {
   }
 
   /**
+   * Check existence of event associated with the eventID
+   *
+   * @param dbClient DB Connection Pool
+   * @param eventId unique event ID associated with the Event
+   * @return {Promise<boolean>} true if exist, false otherwise
+   */
+  static async exist(
+    dbClient: mariadb.Pool,
+    eventId: number
+  ): Promise<boolean> {
+    const queryResult = await dbClient.query(
+      'SELECT EXISTS(SELECT * FROM event WHERE id = ?)',
+      [eventId]
+    );
+    return !!queryResult[0][Object.keys(queryResult[0])[0]];
+  }
+
+  /**
    * Update an existing event
    *
    * @param dbClient DB Connection Pool

--- a/src/datatypes/participate/Participation.ts
+++ b/src/datatypes/participate/Participation.ts
@@ -135,45 +135,31 @@ export default class Participation {
   }
 
   /**
-   * Retrieve a participate table's entry using eventId, name, and email
+   * Check existence of an entry in participate table
+   *   using eventId, name, and email
    *
    * @param dbClient DB Connection Pool (MariaDB)
    * @param eventId unique id referring the event
    * @param name participant's name
    * @param email participant's email
-   * @return {Promise<Participation | undefined>} either undefined
-   *   or found Participation
+   * @return {Promise<boolean>} true if exist, false if not exist
    */
-  static async readByEventIdNameEmail(
+  static async existByEventIdNameEmail(
     dbClient: mariadb.Pool,
     eventId: number,
     name: string,
     email: string
-  ): Promise<Participation | undefined> {
+  ): Promise<boolean> {
     // DB Query
     const queryResult = await dbClient.query(
       String.prototype.concat(
+        'SELECT EXISTS(',
         'SELECT * FROM participation ',
-        'WHERE event_id = ? AND participant_name = ? AND email = ?'
+        'WHERE event_id = ? AND participant_name = ? AND email = ?)'
       ),
       [eventId, name, email]
     );
-
-    if (queryResult.length === 0) {
-      return undefined;
-    } else {
-      const {id, event_id, date} = queryResult[0];
-      const {participant_name, phone_number, email, comment} = queryResult[0];
-      return new Participation(
-        event_id,
-        new Date(date),
-        participant_name,
-        email,
-        phone_number,
-        comment,
-        id
-      );
-    }
+    return !!queryResult[0][Object.keys(queryResult[0])[0]];
   }
 
   /**

--- a/src/routes/participate.ts
+++ b/src/routes/participate.ts
@@ -40,12 +40,14 @@ participateRouter.post('/', async (req, res, next) => {
     }
 
     // Check Event Existence
-    await Event.read(dbClient, eventId);
+    if (!(await Event.exist(dbClient, eventId))) {
+      throw new NotFoundError();
+    }
 
     // Check duplicated (having same name and email)
     const {participantName, email, phoneNumber, comment} = participationForm;
     if (
-      await Participation.readByEventIdNameEmail(
+      await Participation.existByEventIdNameEmail(
         dbClient,
         eventId,
         participantName,
@@ -88,7 +90,9 @@ participateRouter.get('', async (req, res, next) => {
     }
 
     // Check for event existence
-    await Event.read(dbClient, eventId);
+    if (!(await Event.exist(dbClient, eventId))) {
+      throw new NotFoundError();
+    }
 
     // DB Operation
     const participationList = await Participation.readByEventId(

--- a/test/TestEnv.ts
+++ b/test/TestEnv.ts
@@ -90,9 +90,9 @@ export default class TestEnv {
         'CREATE TABLE admin_session (',
         'username VARCHAR(12) NOT NULL UNIQUE,',
         'FOREIGN KEY (username) REFERENCES admin(username) ON DELETE CASCADE ON UPDATE CASCADE,',
+        'INDEX index_username(username),',
         'token VARCHAR(255) NOT NULL PRIMARY KEY,',
-        'expires TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,',
-        'INDEX index_expires(expires)',
+        'expires TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP',
         ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;'
       )
     );
@@ -120,10 +120,13 @@ export default class TestEnv {
         'id INT(11) NOT NULL AUTO_INCREMENT PRIMARY KEY,',
         'event_id INT(11) NOT NULL,',
         'FOREIGN KEY (event_id) REFERENCES event(id) ON DELETE CASCADE ON UPDATE CASCADE,',
+        'INDEX index_event_id(event_id),',
         'date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,',
         'participant_name VARCHAR(255) NOT NULL,',
+        'INDEX index_participant_name(participant_name),',
         'phone_number VARCHAR(20) NULL DEFAULT NULL,',
         'email VARCHAR(255) NOT NULL,',
+        'INDEX index_email(email),',
         'comment TEXT NULL DEFAULT NULL',
         ') CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;'
       )

--- a/test/testcases/auth/post.login.test.ts
+++ b/test/testcases/auth/post.login.test.ts
@@ -9,6 +9,7 @@ import * as request from 'supertest';
 import * as jwt from 'jsonwebtoken';
 import TestEnv from '../../TestEnv';
 import AuthToken from '../../../src/datatypes/authentication/AuthToken';
+import deleteAdmin from '../../../src/functions/utils/deleteAdmin';
 
 describe('POST /auth/login - login', () => {
   let testEnv: TestEnv;
@@ -181,6 +182,27 @@ describe('POST /auth/login - login', () => {
       'testuser1'
     );
     expect(queryResult.length).toBe(0);
+  });
+
+  test('Fail - Removed User', async () => {
+    // Call deleteAdmin function
+    const result = await deleteAdmin('testuser1', testEnv.testConfig);
+    expect(result.affectedRows).toBe(1);
+
+    // login request
+    const loginCredentials = {
+      username: 'testuser1',
+      password: 'Password13!',
+    };
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(401);
+    loginCredentials.username = 'testuser1_r';
+    response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(401);
   });
 
   test('Fail - Not existing user', async () => {

--- a/test/testcases/integrated.test.ts
+++ b/test/testcases/integrated.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Jest tests to check whether data deleted/updated as intended when related
+ *   entry removed/changed.
+ *
+ * @author Hyecheol (Jerry) Jang <hyecheol123@gmail.com>
+ */
+
+// eslint-disable-next-line node/no-unpublished-import
+import * as request from 'supertest';
+import TestEnv from '../TestEnv';
+import deleteAdmin from '../../src/functions/utils/deleteAdmin';
+
+describe('Integrated DB Test', () => {
+  let testEnv: TestEnv;
+
+  // Information that used during the test
+  const loginCredentials = {username: 'testuser1', password: 'Password13!'};
+
+  beforeAll(() => {
+    jest.setTimeout(120000);
+  });
+
+  beforeEach(async () => {
+    // Setup test environment
+    testEnv = new TestEnv(expect.getState().currentTestName);
+
+    // Start Test Environment
+    await testEnv.start();
+  });
+
+  afterEach(async () => {
+    await testEnv.stop();
+  });
+
+  test('Admin Session removed when Admin removed', async () => {
+    // Login Request (Create Admin Session)
+    const response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+
+    // Remove Admin account
+    const result = await deleteAdmin('testuser1', testEnv.testConfig);
+    expect(result.affectedRows).toBe(1);
+
+    // DB Check (Admin session also removed)
+    const queryResult = await testEnv.dbClient.query(
+      "SELECT * FROM admin_session WHERE username = 'testuser1'"
+    );
+    expect(queryResult.length).toBe(0);
+  });
+
+  test('Event remains when Admin removed', async () => {
+    // Remove Admin account
+    const result = await deleteAdmin('testuser1', testEnv.testConfig);
+    expect(result.affectedRows).toBe(1);
+
+    // DB Check (Event remains when Admin removed)
+    let queryResult = await testEnv.dbClient.query('SELECT * FROM event');
+    expect(queryResult.length).toBe(4);
+    queryResult = await testEnv.dbClient.query(
+      "SELECT * FROM event WHERE editor = 'testuser1'"
+    );
+    expect(queryResult.length).toBe(2);
+    queryResult.forEach(
+      (qr: {
+        name: string;
+        date: string;
+        detail: string | null;
+        category: string | null;
+      }) => {
+        if (qr.name === '할로윈 파티') {
+          expect(new Date(qr.date).toISOString()).toBe(
+            new Date(2021, 9, 31).toISOString()
+          );
+          expect(qr.detail).toBeNull();
+          expect(qr.category).toBe('네트워킹');
+        } else if (qr.name === '연말 결산 모임') {
+          expect(new Date(qr.date).toISOString()).toBe(
+            new Date(2021, 11, 31).toISOString()
+          );
+          expect(qr.detail).toBe(
+            '연말을 맞아 BGM 회원끼리 모여 서로의 일년은 어땠는지, 내년 목표는 무엇인지에 관해 이야기해보려 합니다.'
+          );
+          expect(qr.category).toBeNull();
+        } else {
+          fail();
+        }
+      }
+    );
+  });
+
+  test('Participation removed when Event removed', async () => {
+    // Login Request (Get access token)
+    let response = await request(testEnv.expressServer.app)
+      .post('/auth/login')
+      .send(loginCredentials);
+    expect(response.status).toBe(200);
+    const accessToken = response.header['set-cookie'][0]
+      .split('; ')[0]
+      .split('=')[1];
+
+    // Remove event
+    response = await request(testEnv.expressServer.app)
+      .delete('/event/1')
+      .set('Cookie', [`X-ACCESS-TOKEN=${accessToken}`]);
+    expect(response.status).toBe(200);
+
+    // DB Check (Participation removed when Event removed)
+    const queryResult = await testEnv.dbClient.query(
+      'SELECT * FROM participation WHERE event_id = 1'
+    );
+    expect(queryResult.length).toBe(0);
+  });
+});

--- a/test/testcases/integrated.test.ts
+++ b/test/testcases/integrated.test.ts
@@ -61,6 +61,10 @@ describe('Integrated DB Test', () => {
     queryResult = await testEnv.dbClient.query(
       "SELECT * FROM event WHERE editor = 'testuser1'"
     );
+    expect(queryResult.length).toBe(0);
+    queryResult = await testEnv.dbClient.query(
+      "SELECT * FROM event WHERE editor = 'testuser1_r'"
+    );
     expect(queryResult.length).toBe(2);
     queryResult.forEach(
       (qr: {


### PR DESCRIPTION
close #32 

### Change Logs

DB
- INDEX를 적절히 추가
- admin 계정 삭제 시 실제로 지우는 것이 아닌 _r 접미어를 사용하여 마킹
  - event가 지워지지 않도록 하기 위함
- 단순히 엔트리의 존재 유무만 판단하기 위한 EXISTS 쿼리 사용
